### PR TITLE
Fix access log crash on requiest without  body

### DIFF
--- a/src/cowboy_access_log_h.erl
+++ b/src/cowboy_access_log_h.erl
@@ -118,6 +118,8 @@ prepare_meta(Code, Headers, #{req := Req, meta:= Meta0, ext_fun := F}) ->
     AccessMeta1 = maps:merge(get_process_meta(), AccessMeta),
     maps:merge(F(Req), AccessMeta1).
 
+%% NOTE: There is a bug with cowboy_req:has_body/1 in cowboy prior 2.7.0
+%% see https://github.com/ninenines/cowboy/issues/1417
 get_request_body_length(Req) ->
     try cowboy_req:has_body(Req) of
         false -> undefined;


### PR DESCRIPTION
Fix for 
```
Log access failed for: [400, #{<<"connection">> => <<"close">>,<<"content-length">> => <<"0">>}, #{headers => #{<<"accept">> => <<"image/gif, i"...>>,<<"accept-chars"...>> => <<"iso-8859-1,*"...>>,<<"accept-langu"...>> => <<"en">>,<<"cache-co"...>> => <<"no-cache">>,...},method => <<"GET">>,path => <<"/acute-cp/">>,peer => {{10756,18944,...},48951},...}]
with: error:function_clause
stacktrace: in call to cowboy_req:has_body(#{headers => #{<<"accept">> => <<"image/gif, image/x-xbitm...">...) at /home/jenkins/jenkins-agent/jenkins-agent/workspace/ey_private_fistful-server_master/_build/default/lib/cowboy/src/cowboy_req.erl:466
	called from cowboy_access_log_h:get_request_body_length/1 at /home/jenkins/jenkins-agent/jenkins-agent/workspace/ey_private_fistful-server_master/_build/default/lib/cowboy_access_log/src/cowboy_access_log_h.erl:122
	called from cowboy_access_log_h:prepare_meta/3 at /home/jenkins/jenkins-agent/jenkins-agent/workspace/ey_private_fistful-server_master/_build/default/lib/cowboy_access_log...
```